### PR TITLE
Updated Syncing Columns

### DIFF
--- a/sheetData.ts
+++ b/sheetData.ts
@@ -50,7 +50,7 @@ class SheetData {
      * @memberof SheetData
      */
     addKeys(thingToCopyFrom: SheetData) {
-        this.rsd.syncDataColumns(thingToCopyFrom.rsd)
+        this.rsd.syncDataColumns(thingToCopyFrom.rsd,this)
         return this
     }
 
@@ -413,7 +413,7 @@ class RawSheetData {
      * @param {RawSheetData} inputSheetData
      * @memberof RawSheetData
      */
-    syncDataColumns(inputSheetData: RawSheetData) {
+    syncDataColumns(inputSheetData: RawSheetData,self:SheetData) {
         // this has been updated so that you can use any remote / not remote thing
         // let formSheetData = allSheetData.form;
         // let dataSheetData = allSheetData.data;
@@ -421,15 +421,25 @@ class RawSheetData {
 
 
         let addedKeys: any[] = [];
-
-
+        //TODO REMOVE
+        let ignoredKeys: any[] = []
+        // BEEBOOO: FOR FINDING MORE QUICKLY.
+        // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
-            if (!inputSheetData.keyNamesToIgnore.includes(key) && !inputSheetData.hasKey(key)) {
+            if (!inputSheetData.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
                 let header = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
                 inputSheetData.addColumnWithHeader_(key, header);
                 addedKeys.push(key);
+            }   
+            else {
+                ignoredKeys.push(key)
             }
         }
+        // TODO REMOVE
+        if (ignoredKeys.includes("EXTRA WORDS FOR FUN BABYYYY")) {
+            console.error("TESTING KEY SKIPPED");
+        }
+        
 
         let addedStr =
             addedKeys.length == 0
@@ -444,6 +454,7 @@ class RawSheetData {
             addedStr
         );
         console.log(inputSheetData.getKeys().toString());
+
     }
 
     /**

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -421,15 +421,24 @@ class RawSheetData {
 
 
         let addedKeys: any[] = [];
-        //TODO REMOVE
+        //TODO REMOVE ignoredKeys once this is over??
         let ignoredKeys: any[] = []
         // BEEBOOO: FOR FINDING MORE QUICKLY.
         // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
             if (!inputSheetData.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
-                let header = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
-                inputSheetData.addColumnWithHeader_(key, header);
-                addedKeys.push(key);
+                let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
+                
+                // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???
+                let selfHeader = self.getHeaders()
+                if (selfHeader.includes(key) || selfHeader.includes(keyPrettyName)) {
+                    console.warn("SKIPPED KEY BECAUSE IT ALREADY HAD A MATCH")
+                    ignoredKeys.push(key)
+                } else {
+                    // if there isn't anything that matches, *then* push the thingy out.
+                    self.rsd.addColumnWithHeader_(key, keyPrettyName);
+                    addedKeys.push(key);
+                }
             }   
             else {
                 ignoredKeys.push(key)

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -407,6 +407,18 @@ class RawSheetData {
 
     //Private class methods
 
+    renameKey(targetKey: string, newName: string):void {
+        let currentKeys = this.keyToIndex
+        if(!currentKeys.hasOwnProperty(targetKey)){ return}
+        let targetColumn = currentKeys[targetKey]
+
+        this.keyToIndex[newName] = targetColumn
+        this.indexToKey[targetColumn] = newName
+        // this.keyToIndex[key] = index;
+
+        // this.indexToKey[index] = key;
+    }
+
     /**
      * Applies any missing keys from a rawSheetData instance to the current rawSheetData object.
      *
@@ -427,17 +439,22 @@ class RawSheetData {
         // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
             // changed check for key names to ignore, now it runs on self instead of the other one.
-            if (!this.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
+            if (!this.keyNamesToIgnore.includes(key) && !this.hasKey(key)) {
                 let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
                 
                 // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???
-                let selfHeader = self.getHeaders()
-                if (selfHeader.includes(key) || selfHeader.includes(keyPrettyName)) {
+                let selfHeader = this.getHeaders();
+                if (selfHeader.includes(key)){
+                    console.warn("SKIPPED KEY BECAUSE IT ALREADY HAD A MATCH");
+                    ignoredKeys.push(key)
+                } else if(selfHeader.includes(keyPrettyName)) {
                     console.warn("SKIPPED KEY BECAUSE IT ALREADY HAD A MATCH")
                     ignoredKeys.push(key)
+                    this.renameKey(keyPrettyName, key) // This *should* rename keys internally if they match: This should let me have persistent partial soft-coded columns.
+                    
                 } else {
                     // if there isn't anything that matches, *then* push the thingy out.
-                    self.rsd.addColumnWithHeader_(key, /*keyPrettyName*/key); // if key isn't specified key & keyPrettyName will match; we want things to sync in the future: this lets us do partially-hard-coded stuff.
+                    this.addColumnWithHeader_(key, /*keyPrettyName*/key); // if key isn't specified key & keyPrettyName will match; we want things to sync in the future: this lets us do partially-hard-coded stuff.
                     addedKeys.push(key);
                 }
             }   
@@ -447,7 +464,7 @@ class RawSheetData {
         }
         // TODO REMOVE
         if (ignoredKeys.includes("EXTRA WORDS FOR FUN BABYYYY")) {
-            console.error("TESTING KEY SKIPPED");
+            console.error("TESTING KEYS SKIPPED: ",ignoredKeys);
         }
         
 

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -427,7 +427,7 @@ class RawSheetData {
         // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
             // changed check for key names to ignore, now it runs on self instead of the other one.
-            if (!this.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
+            if (!self.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
                 let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
                 
                 // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???
@@ -437,7 +437,7 @@ class RawSheetData {
                     ignoredKeys.push(key)
                 } else {
                     // if there isn't anything that matches, *then* push the thingy out.
-                    self.rsd.addColumnWithHeader_(key, keyPrettyName);
+                    self.rsd.addColumnWithHeader_(key, /*keyPrettyName*/key); // if key isn't specified key & keyPrettyName will match; we want things to sync in the future: this lets us do partially-hard-coded stuff.
                     addedKeys.push(key);
                 }
             }   

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -426,7 +426,8 @@ class RawSheetData {
         // BEEBOOO: FOR FINDING MORE QUICKLY.
         // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
-            if (!inputSheetData.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
+            // changed check for key names to ignore, now it runs on self instead of the other one.
+            if (!self.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
                 let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
                 
                 // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -427,7 +427,7 @@ class RawSheetData {
         // Currently trying to figure out why keys are not getting synchronized.
         for (let key of inputSheetData.getKeys()) {
             // changed check for key names to ignore, now it runs on self instead of the other one.
-            if (!self.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
+            if (!this.keyNamesToIgnore.includes(key) && !self.hasKey(key)) {
                 let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
                 
                 // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???


### PR DESCRIPTION
Column syncing logic has been significantly improved.

Keys will be added from a ``sheetData`` class if they meet the following criteria:

1. The key is not on the blocklist for the ``sheetData`` instance that called the merge.
2. The key does not already exist.

While merging, the following things happen:

1. Keys that do not exist will be added.
2. Soft-coded columns (ones not explicitly declared in config files) will be merged.
   - If a soft-coded column's key matches the header for the specified ``sheetData`` that has a hard-coded key name, the soft-coded key's name will be replaced with the hard-coded one.  This means that you can have a mixture of hard-coded and soft-coded keys in different ``sheetData`` classes and still be able to repeatedly merge and get the same result. 

There is one caveat:
any given sheetData class cannot have two identical header entries or key entries.  Otherwise the left-most (for headers), and smallest column assignment (for hard-coded entries) will be used and the rest will be ignored.