### PR TITLE
Further support for timeseries data, added aggregation functions.

### DIFF
--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -161,10 +161,56 @@ class kiDataClass {
                 }
                 outData[key].push(entry);
             } else {
-                console.error("timeseries key not specified.");
+                console.error("key not specified.");
             }
         }
         return outData;
+    }
+    /**
+     * addGranulatedTime : Similar to groupByTime, but instead of grouping, it just adds a calculated time value to a new key.
+     *
+     * @param {string} timeSeriesKey
+     * @param {string} newKey
+     * @param {timeGranularities} granularity
+     * @return {*}  {this}
+     * @memberof kiDataClass
+     */
+    addGranulatedTime(timeSeriesKey: string, newKey:string,granularity: timeGranularities): this {
+        let data = this.data;
+        // let outData: manyKiDataEntries = {};
+        // let test: kiDataEntry = {};
+
+        for (let entry of data) {
+            if (entry.hasOwnProperty(timeSeriesKey)) {
+                let date: Date = new Date(entry[timeSeriesKey]);
+                // I used a case statement (without breaks, for the most part) because it removes redundancy- we're comparing by .getUTCTime, which gives us milliseconds.
+                // This is the integer equivalent of .floor'ing something at increasing orders of magnitude.
+                switch (granularity) {
+                    case timeGranularities.year:
+                        date.setUTCMonth(0); // note: the lack of breaks here is ON PURPOSE.  See the above note for why.
+                    case timeGranularities.month:
+                        date.setUTCDate(1); // oddly enough, if set to zero, it'll give the 31st of (the month before?)... super weird.
+                    case timeGranularities.day:
+                        date.setUTCHours(0);
+                    case timeGranularities.hour:
+                        date.setUTCMinutes(0);
+                    case timeGranularities.minute:
+                        date.setUTCSeconds(0);
+                    case timeGranularities.second:
+                        date.setUTCMilliseconds(0);
+                    case timeGranularities.millisecond:
+                        break;
+                    default:
+                        console.error("YOU SHOULDN'T BE HERE!");
+                }
+
+                let time = date.getUTCDate();
+                entry[newKey] = time
+            } else {
+                console.error("timeseries key not accessible.");
+            }
+        }
+        return this;
     }
     /**
  *  groupByTime: first thing written specifixally for time-series data: this splits a sheetData into an object of sheetDatas organized by timestamp.

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -204,7 +204,7 @@ class kiDataClass {
                         console.error("YOU SHOULDN'T BE HERE!");
                 }
 
-                let time = date.getUTCDate();
+                let time = date.toUTCString();
                 entry[newKey] = time
             } else {
                 console.error("timeseries key not accessible.");

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -127,7 +127,7 @@ class kiDataClass {
                         }
                         if (!subEntry.hasOwnProperty(targetKeyString)) {
                             subEntry[targetKeyString] = 0;
-                            keysToKeep.push(targetKeyString);
+                            newKeys.push(targetKeyString);
                         }
                         subEntry[targetKeyString] += 1;
                     }
@@ -138,7 +138,7 @@ class kiDataClass {
                 outData.push(subEntry);
             } else {
                 for (let key in inputObject) {
-                    aggData_(depthLevels - 1, inputObject[key]/* This lets me target one layer into the inputObject every time. */, dataPassthrough, keysToAggregate, keysToKeep, shardKey, keysToKeep);
+                    aggData_(depthLevels - 1, inputObject[key], dataPassthrough, keysToAggregate, keysToKeep, shardKey, newKeys);
                 }
             }
             return { data: outData, newKeys: newKeys };

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -159,9 +159,9 @@ class kiDataClass {
         
         let newKeys: string[] = []
         
-        let aggDataCombo = aggData_(groupingKeys.length, groupedData, [], groupingKeys, allKeysToKeep, shardKey, newKeys)
+        let aggDataCombo:aggDataReturn = aggData_(groupingKeys.length, groupedData, [], groupingKeys, allKeysToKeep, shardKey, newKeys)
 
-        let aggData = aggDataCombo.data
+        let aggData:kiDataEntry[] = aggDataCombo.data
 
         // Step 3: Update internal key list.
         for (let key of aggDataCombo.newKeys) {
@@ -170,6 +170,9 @@ class kiDataClass {
             }
         }
 
+        this.data = aggData
+
+        return this
 
 
 

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -27,6 +27,7 @@ interface manyKiDataClasses {
 }
 
 // !Warning!  This will probably get deprecated in favor of kiDataEntry[]
+// ! This is *not* what you want to use for kiDataClass work: this is for funky weird edge cases like making keyed objects of kiDataEntry[] arrays.
 interface manyKiDataEntries { // array of kiDataEntries
     [index: number]: kiDataEntry;
 }
@@ -73,6 +74,22 @@ class kiDataClass {
     get end(): kiDataEntry[] {
         return this.data;
     }
+    /**
+     *  this is a complement to breakdownAnalysis: but instead of making a separate line for each entry, we're aggregating all the entries and turning them into their own columns / keys. 
+     *
+     * @param {string[]} KeysToKeep // keys that are passed through to the final entry.
+     * @param {string[]} KeysToLumpBy // keys to sort by: Do you want to keep things apart based on git commit?  trigger type?
+     * @param {string[]} KeysToAggregate // what row is getting turned into a column?
+     * @param {string[]} shardKey // for debug stuff, I'll figure out a better way to name this in the future.  Extra specifier for keysToAggregate.
+     * @return {*}  {this}
+     * @memberof kiDataClass
+     */
+    dataLumper(KeysToKeep:string[], KeysToLumpBy: string[], KeysToAggregate: string[],shardKey:string|null = null):this {
+        // this might be harder than breakdownAnalysis was to figure out.
+        
+
+        return this
+    }
 
     /**
  *  groupByTime: first thing written specifixally for time-series data: this splits a sheetData into an object of sheetDatas organized by timestamp.
@@ -98,9 +115,9 @@ class kiDataClass {
                 // This is the integer equivalent of .floor'ing something at increasing orders of magnitude.
                 switch (granularity) {
                 case timeGranularities.year:
-                    date.setUTCMonth(1)
+                    date.setUTCMonth(0) // note: the lack of breaks here is ON PURPOSE.  See the above note for why.
                 case timeGranularities.month:
-                    date.setUTCDate(1)
+                    date.setUTCDate(1) // oddly enough, if set to zero, it'll give the 31st of (the month before?)... super weird.
                 case timeGranularities.day:
                     date.setUTCHours(0)
                 case timeGranularities.hour:
@@ -121,15 +138,10 @@ class kiDataClass {
                     outData[time] = []
                 }
                 outData[time].push(entry)
-
             } else {
                 console.error("timeseries key not specified.")
             }
-
-
         }
-
-
         return outData;
     }
     /**

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -73,7 +73,7 @@ class kiDataClass {
         this.internalKeys = [];
         // adds keys: this is to make it a little easier to do programatic work with data structures.
         for (let entry of kiData) {
-            for (let key of entry) {
+            for (let key in entry) {
                 if (!this.internalKeys.includes(key)) {
                     this.internalKeys.push(key)
                 }
@@ -122,8 +122,8 @@ class kiDataClass {
                     // for (let entry of inputObject[key]) {
                     for (let aggKey of keysToAggregate) {
                         let targetKeyString = key[aggKey];
-                        if (shardKey != null && subEntry.hasOwnProperty(shardKey) && subEntry[shardKey] != "") {
-                            targetKeyString += subEntry[shardKey];
+                        if (shardKey != null && key.hasOwnProperty(shardKey) && key[shardKey] != "") {
+                            targetKeyString += key[shardKey];
                         }
                         if (!subEntry.hasOwnProperty(targetKeyString)) {
                             subEntry[targetKeyString] = 0;
@@ -159,7 +159,7 @@ class kiDataClass {
         
         let newKeys: string[] = []
         
-        let aggDataCombo:aggDataReturn = aggData_(groupingKeys.length, groupedData, [], groupingKeys, allKeysToKeep, shardKey, newKeys)
+        let aggDataCombo:aggDataReturn = aggData_(groupingKeys.length, groupedData, [], keysToAggregateBy, allKeysToKeep, shardKey, newKeys)
 
         let aggData:kiDataEntry[] = aggDataCombo.data
 

--- a/dataManipulator.ts
+++ b/dataManipulator.ts
@@ -65,24 +65,24 @@ class kiDataClass {
         }
     };
     data: kiDataEntry[] = [];
-    internalKeys: string[];
+    additionalKeys: string[];
 
     constructor(kiData) {
         this.data = [];
         this.data = kiData;
-        this.internalKeys = [];
+        this.additionalKeys = [];
         // adds keys: this is to make it a little easier to do programatic work with data structures.
-        for (let entry of kiData) {
-            for (let key in entry) {
-                if (!this.internalKeys.includes(key)) {
-                    this.internalKeys.push(key)
-                }
-            }
-        }
+        // for (let entry of kiData) {
+        //     for (let key in entry) {
+        //         if (!this.internalKeys.includes(key)) {
+        //             this.internalKeys.push(key)
+        //         }
+        //     }
+        // }
     }
 
-    get keys(): string[] {
-        return this.internalKeys
+    get newKeys(): string[] {
+        return this.additionalKeys
     }
 
 
@@ -165,8 +165,8 @@ class kiDataClass {
 
         // Step 3: Update internal key list.
         for (let key of aggDataCombo.newKeys) {
-            if (!this.internalKeys.includes(key)) {
-                this.internalKeys.push(key)
+            if (!this.additionalKeys.includes(key)) {
+                this.additionalKeys.push(key)
             }
         }
 

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -406,8 +406,15 @@ class RawSheetData {
 
 
     //Private class methods
-
-    renameKey(targetKey: string, newName: string):void {
+    
+    /**
+     *  renameKey: Replaces the name of a key with a given string.  If the given key does not exist, it will return without doing anything.
+     *
+     * @param {string} targetKey
+     * @param {string} newName
+     * @memberof RawSheetData
+     */
+    renameKey(targetKey: string, newName: string): void {
         let currentKeys = this.keyToIndex
         if(!currentKeys.hasOwnProperty(targetKey)){ return}
         let targetColumn = currentKeys[targetKey]
@@ -419,13 +426,29 @@ class RawSheetData {
         // this.indexToKey[index] = key;
     }
 
-    /**
-     * Applies any missing keys from a rawSheetData instance to the current rawSheetData object.
-     *
+    /** syncDataColumns
+     *  
+     *  Applies any missing keys from a rawSheetData instance to the current rawSheetData object.
+     *  Keys will be added from a ``sheetData`` class if they meet the following criteria:
+     *  1. The key is not on the blocklist for the ``sheetData`` instance that called the merge.
+     *  2. The key does not already exist.
+     *  While merging, the following things happen:
+     *  1. Keys that do not exist will be added.
+     *  2. Soft-coded columns (ones not explicitly declared in config files) will be merged.
+     *    - If a soft-coded column's key matches the header for the specified ``sheetData`` 
+     *       that has a hard-coded key name, the soft-coded key's name will be replaced with 
+     *       the hard-coded one.  This means that you can have a mixture of hard-coded and 
+     *       soft-coded keys in different ``sheetData`` classes and still be able to repeatedly
+     *       merge and get the same result. 
+     * 
+     *  There is one caveat:
+     *   any given sheetData class cannot have two identical header entries or key entries.
+     *   Otherwise the left-most (for headers), and smallest column assignment (for hard-coded 
+     *   entries) will be used and the rest will be ignored.
      * @param {RawSheetData} inputSheetData
      * @memberof RawSheetData
      */
-    syncDataColumns(inputSheetData: RawSheetData,self:SheetData) {
+    syncDataColumns(inputSheetData: RawSheetData,self:SheetData): void {
         // this has been updated so that you can use any remote / not remote thing
         // let formSheetData = allSheetData.form;
         // let dataSheetData = allSheetData.data;
@@ -491,7 +514,7 @@ class RawSheetData {
      * @return {*}  {sheetDataEntry}
      * @memberof RawSheetData
      */
-    getEntryConfig(isForCaching:boolean = false):sheetDataEntry {
+    getEntryConfig(isForCaching:boolean = false): sheetDataEntry {
         let outEntry: sheetDataEntry = {
             tabName: this.tabName,
             headerRow: this.headerRow,
@@ -524,7 +547,7 @@ class RawSheetData {
      * @param {boolean} [writeInDataArea=false]
      * @memberof RawSheetData
      */
-    directEditRawSheetValues(xOffset: number, yOffset: number, valueArray: any[][], writeInDataArea = false) {
+    directEditRawSheetValues(xOffset: number, yOffset: number, valueArray: any[][], writeInDataArea = false): void {
         if (yOffset + valueArray.length > this.getHeaderRow() && !writeInDataArea) {
             console.warn("Tried to write to protected row in sheet" + this.getTabName());
         } else {

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -49,7 +49,7 @@ class SheetData {
      * @return {*} 
      * @memberof SheetData
      */
-    addKeys(thingToCopyFrom: SheetData) {
+    addKeys(thingToCopyFrom: SheetData):this {
         this.rsd.syncDataColumns(thingToCopyFrom.rsd,this)
         return this
     }

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -42,6 +42,14 @@ class SheetData {
         this.rsd = rawSheetData;
     }
 
+    clearRows(numRows: number) {
+        if (typeof numRows == typeof 12) {
+            this.rsd.deleteUntilRow(numRows)
+        } else {
+            console.error("NumRows call invalid, not deleting.")
+        }
+    }
+
     /**
      *  Copies all keys that don't already exist that are not specifically excluded in the keyNamesToIgnore declaration 
         
@@ -1107,6 +1115,16 @@ class RawSheetData {
         if (numRows <= 0) return; //End if the sheet is already empty
         let numCols = this.getSheet().getLastColumn();
         this.getSheet().getRange(startRow, 1, numRows + 1, numCols).clearContent();
+    }
+    deleteUntilRow(finalRow:number) {
+        let startRow = this.getHeaderRow() + 2;
+        let numRows = this.getSheet().getLastRow() + 1 - startRow;
+        if (numRows <= 0) return; //End if the sheet is already empty
+        let numCols = this.getSheet().getLastColumn();
+        if (finalRow <= numRows) {
+            this.getSheet().getRange(startRow, 1, finalRow + 1, numCols).clearContent();
+            
+        }
     }
 
     /**

--- a/sheetData.ts
+++ b/sheetData.ts
@@ -53,6 +53,10 @@ class SheetData {
         this.rsd.syncDataColumns(thingToCopyFrom.rsd,this)
         return this
     }
+    addKeysFromArray(keyArray: string[]): this {
+        this.rsd.addColumnsFromArray(keyArray, this);
+        return this;
+    }
 
     getConfigForCache() {
         return this.rsd.getEntryConfig(true)
@@ -424,6 +428,61 @@ class RawSheetData {
         // this.keyToIndex[key] = index;
 
         // this.indexToKey[index] = key;
+    }
+
+    
+    addColumnsFromArray(keyArray:string[], self: SheetData): void {
+        // this has been updated so that you can use any remote / not remote thing
+        // let formSheetData = allSheetData.form;
+        // let dataSheetData = allSheetData.data;
+
+
+
+        let addedKeys: any[] = [];
+        //TODO REMOVE ignoredKeys once this is over??
+        let ignoredKeys: any[] = [];
+        // BEEBOOO: FOR FINDING MORE QUICKLY.
+        // Currently trying to figure out why keys are not getting synchronized.
+        for (let key of keyArray) {
+            // changed check for key names to ignore, now it runs on self instead of the other one.
+            if (!this.keyNamesToIgnore.includes(key) && !this.hasKey(key)) {
+                // let keyPrettyName = inputSheetData.getHeaders()[inputSheetData.getIndex(key)];
+
+                // checking to make sure that something with the same name doesn't already exist.  This might be a bad idea???
+                let selfHeader = this.getHeaders();
+                if (selfHeader.includes(key)) {
+                    console.warn("SKIPPED KEY BECAUSE IT ALREADY HAD A MATCH");
+                    ignoredKeys.push(key);
+                } else {
+                    // if there isn't anything that matches, *then* push the thingy out.
+                    this.addColumnWithHeader_(key, /*keyPrettyName*/key); // if key isn't specified key & keyPrettyName will match; we want things to sync in the future: this lets us do partially-hard-coded stuff.
+                    addedKeys.push(key);
+                }
+            }
+            else {
+                ignoredKeys.push(key);
+            }
+        }
+        // // TODO REMOVE
+        // if (ignoredKeys.includes("EXTRA WORDS FOR FUN BABYYYY")) {
+        //     console.error("TESTING KEYS SKIPPED: ", ignoredKeys);
+        // }
+
+
+        let addedStr =
+            addedKeys.length == 0
+                ? "No new columns in keyArray"
+                : addedKeys.toString();
+        console.log(
+            "Added " +
+            addedKeys.length +
+            " column(s) to " +
+            this.getTabName() +
+            ": " +
+            addedStr
+        );
+        console.log(this.getKeys().toString());
+
     }
 
     /** syncDataColumns

--- a/typescript-interfaces.ts
+++ b/typescript-interfaces.ts
@@ -1,7 +1,7 @@
 // Typescript References
 
 interface aggDataReturn {
-    data: kiDataEntry,
+    data: kiDataEntry[],
     newKeys: string[];
 }
 

--- a/typescript-interfaces.ts
+++ b/typescript-interfaces.ts
@@ -31,6 +31,15 @@ interface manySheetDatas {
     [index: string]: SheetData,
 }
 
+interface recursiveData { // literally no idea if this will work
+    [index: string]: [] | recursiveData
+}
+
+interface recursiveFunctionData{
+    keysLeft: string[],
+    data: {}
+}
+
 interface sheetDataEntry {
     tabName: string,
     headerRow: number,

--- a/typescript-interfaces.ts
+++ b/typescript-interfaces.ts
@@ -1,3 +1,9 @@
+// Typescript References
+
+interface aggDataReturn {
+    data: kiDataEntry,
+    newKeys: string[];
+}
 
 enum timeGranularities {
     year = "year",
@@ -12,19 +18,6 @@ enum timeGranularities {
 interface timeGranularity {
     param:timeGranularities
 }
-// class timeGranularityClass {
-//     year: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "year"
-//     day: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "day"
-//     hour: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "hour"
-//     minute: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "minute"
-//     second: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "second"
-//     millisecond: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "millisecond"
-// }
-
-
-
-// let timeGranularity = new timeGranularityClass()
-
 
 
 interface manySheetDatas {

--- a/typescript-interfaces.ts
+++ b/typescript-interfaces.ts
@@ -1,3 +1,32 @@
+
+enum timeGranularities {
+    year = "year",
+    month = "month",
+    day = "day",
+    hour = "hour",
+    minute = "minute",
+    second = "second",
+    millisecond = "millisecond"
+}
+
+interface timeGranularity {
+    param:timeGranularities
+}
+// class timeGranularityClass {
+//     year: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "year"
+//     day: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "day"
+//     hour: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "hour"
+//     minute: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "minute"
+//     second: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "second"
+//     millisecond: "year" | "day" | "hour" | "minute" | "second" | "millisecond" = "millisecond"
+// }
+
+
+
+// let timeGranularity = new timeGranularityClass()
+
+
+
 interface manySheetDatas {
     [index: string]: SheetData,
 }


### PR DESCRIPTION
In addition to the ``breakdownAnalysis`` method on ``kiDataClass`` the following methods should help with future work:
- ``aggregateByKeys`` - Like a big pivot table, lets you lump things together based on a set of given keys *and* can sum multiple things.
- ``addGranulatedTime`` - essentially a floor function for time- adds a calculated key.
- get ``newKeys`` - Gives new keys calculated by ``aggregateByKeys`` that need to be added to a ``sheetData`` class to get data to Sheets.
- ``groupByTime`` - returns groupings of data in blocks based on a given time key.
- ``groupByKey`` - groupByTime's generalized counterpart.

When tested on the the live KI system's debug log, aggregation was able to reduce 300,000+ entries into ~1300 entries.

 